### PR TITLE
Change default encoding to UTF-8 during file reading

### DIFF
--- a/pandoc_include.py
+++ b/pandoc_include.py
@@ -60,7 +60,7 @@ def action(elem, doc):
         if not os.path.isfile(fn):
             raise ValueError('Included file not found: ' + fn + ' ' + entry + ' ' + os.getcwd())
         
-        with open(fn) as f:
+        with open(fn, encoding="utf-8") as f:
             raw = f.read()
 
         # Save current path


### PR DESCRIPTION
PR related to issue: https://github.com/DCsunset/pandoc-include/issues/4

There was added UTF-8 encoding during opening file, which fix issue with dialect characters in files to include.