### PR TITLE
No failure when file not found, just insert a missing link.

### DIFF
--- a/pandoc_include.py
+++ b/pandoc_include.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 Panflute filter to allow file includes
 
@@ -104,11 +106,10 @@ def action(elem, doc):
         fn = get_filename(elem, includeType)
 
         if not os.path.isfile(fn):
-            raise ValueError('Included file not found: ' +
-                             fn + ' ' + entry + ' ' + os.getcwd())
-
-        with open(fn, encoding="utf-8") as f:
-            raw = f.read()
+            raw = '[`%s`](%s)\n' % (fn, fn if os.path.isabs(fn) else os.path.join(os.getcwd(), fn))
+        else:
+            with open(fn, encoding="utf-8") as f:
+                raw = f.read()
 
         # Save current path
         cur_path = os.getcwd()


### PR DESCRIPTION
Hi, this is a bit of a personal taste and probably mood dependent, but I would rather have the script moving on when a file is not found.

So instead of failing, I propose to insert the filename as a link (broken). The user will notice soon enough, but this allows them to focus on maybe more important issues. 

This patch does not implement a warning message. Is this desirable though?

Note: this pull request is incompatible with #8 .