### PR TITLE
feature: increment section levels of included file

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Supported options:
 | endLine | number | End line of include (default: number of the last line) |
 | snippetStart | string | Start delimiter of a snippet |
 | snippetEnd | string | End delimiter of a snippet |
+| incrementSection | number | Increment (or decrement) section levels of include |
 
 
 ### Header options

--- a/pandoc_include.py
+++ b/pandoc_include.py
@@ -12,7 +12,7 @@ from natsort import natsorted
 from collections import OrderedDict
 
 
-CONFIG_KEYS = {"startLine", "endLine", "snippetStart", "snippetEnd"}
+CONFIG_KEYS = {"startLine", "endLine", "snippetStart", "snippetEnd", "incrementSection"}
 
 def eprint(text):
     print(text, file=sys.stderr)
@@ -240,6 +240,17 @@ def action(elem, doc):
                 os.remove(temp_filename)
             # Restore to current path
             os.chdir(cur_path)
+
+            # incremement headings
+            try:
+                increment = int(config.get('incrementSection', 0))
+            except ValueError:
+                increment = 0
+
+            if increment:
+                for elem in new_elems:
+                    if isinstance(elem, pf.Header):
+                        elem.level += increment
 
             if new_elems != None:
                 elements += new_elems


### PR DESCRIPTION
Thanks for your filter, it works really well. I needed this feature, and it took the whole of 2 minutes to implement, so credit to you for the simple organisation of the project.

Does what says on the tin, adds a config value like so:

```
$include`incrementSection=1` include.md
```

Which then increments all the headings of the included elements as per the config value. I generate a number of include files and I didn't want to jig the generator for the individual files so this made the most sense.

Would be happy to get this merged.
