### PR TITLE
Adding meta data variable for external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Supported options:
 ---
 include-entry: '<path>'
 include-order: 'natural'
+include-resources: '<path>[:<path>]'
 rewrite-path: true
 pandoc-options:
   - --filter=pandoc-include
@@ -201,6 +202,46 @@ The `include-order` options is to define the order of included files if the unix
 The default value is `natural`, which means using the [natural order](https://en.wikipedia.org/wiki/Natural_sort_order).
 Other possible values are `alphabetical` and `default`.
 The `default` means to keep the order returned by the Python `glob` module.
+
+
+#### `include-resources`
+The `include-resources` can be used to simplify relative paths of include statements by searching in the given paths for files with relative paths when otherwise not found.
+
+Given following directory structure and `pandoc` command:
+
+```
+main.md
+examples/
+    hello-world.c
+content/
+    chapter1/
+        chapter01.md
+        image.png
+    chapter2/
+        chapter02.md
+        image.png
+```
+```
+$ pandoc --metadata include-resources=examples/ ... main.md
+```
+
+This will make it possible to have following include line in `chapter01.md` and `chapter02.md`
+````markdown
+```cpp
+!include hello-world.c
+```
+````
+
+Instead of:
+````markdown
+```cpp
+!include ../../examples/hello-world.c
+```
+````
+
+This is most useful if some resources, e.g. source code or Doxygen output,
+is located in an external directory structure.
+
 
 #### `rewrite-path`
 

--- a/pandoc_include/config.py
+++ b/pandoc_include/config.py
@@ -62,6 +62,8 @@ def parseOptions(doc):
         # entry file (default values)
         options = {
             "current-path": ".",
+            "include-resources": ".",
+            "process-path": None,
             "include-order": "natural",
             "rewrite-path": True,
             "pandoc-options": ["--filter=pandoc-include"]
@@ -84,5 +86,15 @@ def parseOptions(doc):
     rewrite_path = doc.get_metadata("rewrite-path")
     if rewrite_path is not None:
         options["rewrite-path"] = rewrite_path
-    
+
+    # resource path
+    resource_path = doc.get_metadata("include-resources")
+    if resource_path is not None:
+        options["include-resources"] = resource_path
+
+    # process path
+    process_path = os.getcwd()
+    if options["process-path"] is None:
+        options["process-path"] = process_path
+
     return options

--- a/pandoc_include/main.py
+++ b/pandoc_include/main.py
@@ -6,6 +6,7 @@ import os
 import json
 import glob
 import re
+import itertools
 
 import panflute as pf
 
@@ -218,8 +219,16 @@ def action(elem, doc):
         if includeType == INCLUDE_INVALID:
             return
 
+        resource_paths = options['include-resources'].split(':')
+
         # Enable shell-style wildcards
         files = glob.glob(name, recursive=True)
+        if len(files) == 0 and resource_paths:
+            for resource_path in resource_paths:
+                if os.path.isabs(resource_path):
+                    files += glob.glob(os.path.normpath(os.path.join(resource_path, name)), recursive=True)
+                else:
+                    files += glob.glob(os.path.normpath(os.path.join(options['process-path'], resource_path, name)), recursive=True)
         if len(files) == 0:
             raise IOError(f"Included file not found: {name}")
 


### PR DESCRIPTION
Adding handling of `resource-path` for includes by adding `include-resources` as meta data variable.

A meta data variable is used as Pandoc does not expose the `resource-path` to panflute filters.