### PR TITLE
fix: allow the XML parser to recover in case of syntax errors

### DIFF
--- a/pandoc_include/main.py
+++ b/pandoc_include/main.py
@@ -164,7 +164,7 @@ def read_file(filename, config: dict):
 
         pf.debug(f"[INFO] xslt transform {filename} with {xslTransformerFile}")
 
-        dom = xml.parse(filename)
+        dom = xml.parse(filename, xml.XMLParser(recover=True))
 
         xslt = xml.parse(xslTransformerFile)
         if not xslt:


### PR DESCRIPTION
fix: allow the XML parser to recover in case of syntax errors for a more robust behavior