### PR TITLE
fix: image inclusion in subdirectories

### DIFF
--- a/pandoc_include/main.py
+++ b/pandoc_include/main.py
@@ -409,8 +409,8 @@ def action(elem, doc):
         if os.path.isabs(url):
             return
 
-        # rewrite relative path
-        elem.url = os.path.join(options["current-path"], url)
+        # rewrite relative to absolute path
+        elem.url = os.path.abspath(url)
 
 
 def main(doc=None):


### PR DESCRIPTION
replace relative image paths with absolute ones
closes #54